### PR TITLE
Add job queue and monitoring script for new audio files

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,18 @@ def get_recordings():
     return [dict(row) for row in rows]
 
 
+@app.get("/api/jobs")
+def get_jobs():
+    """Return all jobs with their status and creation time."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    rows = cursor.execute(
+        "SELECT id, file_path, status, created_at FROM jobs ORDER BY created_at DESC"
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
 @app.get("/api/segments/{recording_id}")
 def get_segments(recording_id: int):
     conn = sqlite3.connect(DB_PATH)

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -66,6 +66,19 @@
     <tbody></tbody>
   </table>
 
+  <h2>Job Queue</h2>
+  <table id="jobs-table">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>File</th>
+        <th>Status</th>
+        <th>Created</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
   <div id="segments" style="margin-top: 2rem; display: none;">
     <button onclick="toggleSegments(false)">🔙 Back to list</button>
     <div id="segment-list"></div>
@@ -140,7 +153,25 @@
       audio.play();
     }
 
+    async function loadJobs() {
+      const res = await fetch('/api/jobs');
+      const jobs = await res.json();
+      const tbody = document.querySelector('#jobs-table tbody');
+
+      jobs.forEach(job => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>${job.id}</td>
+          <td>${job.file_path}</td>
+          <td>${job.status}</td>
+          <td>${job.created_at || ''}</td>
+        `;
+        tbody.appendChild(row);
+      });
+    }
+
     loadRecordings();
+    loadJobs();
   </script>
 </body>
 </html>

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -32,6 +32,13 @@ CREATE TABLE IF NOT EXISTS speakers (
     profile_path TEXT,
     last_seen TEXT
 );
+
+CREATE TABLE IF NOT EXISTS jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path TEXT UNIQUE NOT NULL,
+    status TEXT DEFAULT 'pending',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
 """)
 
 conn.commit()


### PR DESCRIPTION
## Summary
- Add `jobs` table to database initialization script to track pending audio tasks
- Introduce `job_watcher.py` for continuous polling of the audio folder and queuing new files
- Expose `/api/jobs` endpoint and extend dashboard with a Job Queue table showing each job's status

## Testing
- `python -m py_compile app.py scripts/init_db.py scripts/job_watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_6891c36000e883219f189a8fba4f89af