### PR TITLE
Add job processing controls and prevent duplicate queue entries

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -66,6 +66,20 @@
     <tbody></tbody>
   </table>
 
+  <h2>Job Queue</h2>
+  <table id="jobs-table">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>File</th>
+        <th>Status</th>
+        <th>Created</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
   <div id="segments" style="margin-top: 2rem; display: none;">
     <button onclick="toggleSegments(false)">🔙 Back to list</button>
     <div id="segment-list"></div>
@@ -76,6 +90,7 @@
       const res = await fetch('/api/recordings');
       const recordings = await res.json();
       const tbody = document.querySelector("#recordings-table tbody");
+      tbody.innerHTML = '';
 
       recordings.forEach(rec => {
         const row = document.createElement("tr");
@@ -140,7 +155,39 @@
       audio.play();
     }
 
+    async function loadJobs() {
+      const res = await fetch('/api/jobs');
+      const jobs = await res.json();
+      const tbody = document.querySelector('#jobs-table tbody');
+      tbody.innerHTML = '';
+
+      jobs.forEach(job => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>${job.id}</td>
+          <td>${job.file_path}</td>
+          <td>${job.status}</td>
+          <td>${job.created_at || ''}</td>
+          <td><button onclick="processJob(${job.id})">▶️ Start</button></td>
+        `;
+        tbody.appendChild(row);
+      });
+    }
+
+    async function processJob(id) {
+      const res = await fetch(`/api/jobs/${id}/process`, { method: 'POST' });
+      if (res.ok) {
+        alert('✅ Job processed');
+      } else {
+        const data = await res.json().catch(() => ({}));
+        alert(`❌ Failed: ${data.detail || res.status}`);
+      }
+      await loadRecordings();
+      await loadJobs();
+    }
+
     loadRecordings();
+    loadJobs();
   </script>
 </body>
 </html>

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -32,6 +32,13 @@ CREATE TABLE IF NOT EXISTS speakers (
     profile_path TEXT,
     last_seen TEXT
 );
+
+CREATE TABLE IF NOT EXISTS jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path TEXT UNIQUE NOT NULL,
+    status TEXT DEFAULT 'pending',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
 """)
 
 conn.commit()

--- a/scripts/job_watcher.py
+++ b/scripts/job_watcher.py
@@ -1,0 +1,54 @@
+import os
+import time
+import sqlite3
+from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv()
+
+AUDIO_DIR = os.getenv("AUDIO")
+DB_PATH = os.getenv("TRANSCRIPTS_DB")
+POLL_INTERVAL = 60  # seconds
+
+def scan_for_new_files():
+    """Recursively scan the audio directory and queue new files."""
+    if not AUDIO_DIR or not DB_PATH:
+        raise RuntimeError("AUDIO and TRANSCRIPTS_DB must be set in the environment")
+
+    root_dir = Path(AUDIO_DIR)
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+
+    def iter_audio_files():
+        for dirpath, _, filenames in os.walk(root_dir):
+            for name in filenames:
+                if name.lower().endswith(".m4a"):
+                    yield Path(dirpath) / name
+
+    print(f"📡 Monitoring '{root_dir}' for new audio files...")
+    try:
+        while True:
+            for path in iter_audio_files():
+                # Skip files already transcribed
+                cursor.execute("SELECT 1 FROM recordings WHERE filename = ?", (path.name,))
+                if cursor.fetchone():
+                    continue
+
+                # Skip files already queued as jobs
+                cursor.execute("SELECT 1 FROM jobs WHERE file_path = ?", (str(path),))
+                if cursor.fetchone():
+                    continue
+
+                cursor.execute(
+                    "INSERT INTO jobs (file_path, status) VALUES (?, 'pending')",
+                    (str(path),),
+                )
+                conn.commit()
+                print(f"📥 Queued job for: {path}")
+
+            time.sleep(POLL_INTERVAL)
+    finally:
+        conn.close()
+
+if __name__ == "__main__":
+    scan_for_new_files()


### PR DESCRIPTION
## Summary
- Skip already-transcribed files when scanning for new jobs
- Expose `/api/jobs/{id}/process` to run transcription and update job status
- Show a "Start" action in the dashboard job table to trigger processing

## Testing
- `python -m py_compile app.py scripts/init_db.py scripts/job_watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_6891c36000e883219f189a8fba4f89af