### PR TITLE
Add jobs queue cleanup maintenance script

### DIFF
--- a/scripts/cleanup_jobs.py
+++ b/scripts/cleanup_jobs.py
@@ -1,0 +1,41 @@
+import os
+import sqlite3
+from pathlib import Path
+
+try:  # python-dotenv may not be installed
+    from dotenv import load_dotenv  # type: ignore
+except Exception:  # pragma: no cover
+    load_dotenv = lambda: None
+
+load_dotenv()
+
+DB_PATH = os.getenv("TRANSCRIPTS_DB")
+
+
+def cleanup_jobs_queue():
+    """Remove jobs whose recordings already exist in the database."""
+    if not DB_PATH:
+        raise RuntimeError("TRANSCRIPTS_DB must be set in the environment")
+
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT id, file_path FROM jobs")
+    jobs = cursor.fetchall()
+    removed = 0
+
+    for job_id, file_path in jobs:
+        filename = Path(file_path).name
+        cursor.execute("SELECT 1 FROM recordings WHERE filename = ?", (filename,))
+        if cursor.fetchone():
+            cursor.execute("DELETE FROM jobs WHERE id = ?", (job_id,))
+            print(f"🗑️ Removed completed job for: {filename}")
+            removed += 1
+
+    conn.commit()
+    conn.close()
+    print(f"✅ Removed {removed} completed job(s)")
+
+
+if __name__ == "__main__":
+    cleanup_jobs_queue()


### PR DESCRIPTION
## Summary
- add maintenance script to prune jobs queue entries with existing transcripts
- handle missing `python-dotenv` gracefully so script runs in minimal environments

## Testing
- `python -m py_compile scripts/cleanup_jobs.py`
- `TRANSCRIPTS_DB=transcripts.db python scripts/cleanup_jobs.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891d6e626988321a9594427fa649ebd