### PR TITLE
Add speaker identification trigger

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
@@ -14,6 +14,7 @@ app.add_middleware(CORSMiddleware, allow_origins=["*"])
 DB_PATH = Path(__file__).parent / "transcripts.db"
 AUDIO_SEGMENTS_DIR = "/mnt/audio/audio_segments"
 DASHBOARD_DIR = Path(__file__).parent / "dashboard"
+GLOBAL_SPEAKERS_PATH = Path(__file__).parent / "global_speakers.json"
 
 # Static mounts
 app.mount("/dashboard", StaticFiles(directory=DASHBOARD_DIR, html=True), name="dashboard")
@@ -77,7 +78,7 @@ def process_job(job_id: int):
         raise HTTPException(status_code=500, detail=str(e))
     finally:
         conn.close()
-    return {"status": "completed}
+    return {"status": "completed"}
             
 @app.get("/api/segments/{recording_id}")
 def get_segments(recording_id: int):
@@ -120,3 +121,126 @@ def delete_recording(recording_id: int):
     conn.close()
 
     return {"status": "deleted", "id": recording_id}
+
+
+def _compute_segment_feature(path: str) -> float:
+    """Return a simple average absolute amplitude feature for the audio segment."""
+    import wave
+    import struct
+    try:
+        with wave.open(path, "rb") as wf:
+            frames = wf.readframes(wf.getnframes())
+            samples = struct.unpack("<" + "h" * (len(frames) // 2), frames)
+            return sum(abs(s) for s in samples) / max(1, len(samples))
+    except Exception as e:
+        print(f"⚠️ Failed to read {path}: {e}")
+        return 0.0
+
+
+def _kmeans_1d(values, k: int = 2, iterations: int = 20):
+    """Very small 1D k-means implementation using only stdlib."""
+    import random
+
+    if not values:
+        return [], []
+    k = min(k, len(set(values))) or 1
+    centroids = random.sample(values, k)
+    for _ in range(iterations):
+        groups = {i: [] for i in range(k)}
+        for v in values:
+            idx = min(range(k), key=lambda j: abs(v - centroids[j]))
+            groups[idx].append(v)
+        new_centroids = [
+            sum(g) / len(g) if g else centroids[i] for i, g in groups.items()
+        ]
+        if all(abs(new_centroids[i] - centroids[i]) < 1e-3 for i in range(k)):
+            break
+        centroids = new_centroids
+    labels = [min(range(k), key=lambda j: abs(v - centroids[j])) for v in values]
+    return labels, centroids
+
+
+def run_speaker_identification(recording_id: int):
+    import json
+    import math
+
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    rows = cursor.execute(
+        "SELECT id, embedding_path FROM segments WHERE recording_id = ?",
+        (recording_id,),
+    ).fetchall()
+
+    if not rows:
+        conn.close()
+        return
+
+    segment_features = []
+    segment_ids = []
+    for seg_id, path in rows:
+        feature = _compute_segment_feature(path)
+        segment_features.append(feature)
+        segment_ids.append((seg_id, path, feature))
+
+    labels, centroids = _kmeans_1d(segment_features, k=2)
+
+    # Load global speaker data
+    if GLOBAL_SPEAKERS_PATH.exists():
+        global_map = json.loads(GLOBAL_SPEAKERS_PATH.read_text())
+    else:
+        global_map = {}
+
+    next_index = 0
+    for name in global_map.keys():
+        if name.startswith("speaker_"):
+            try:
+                idx = int(name.split("_")[1])
+                next_index = max(next_index, idx + 1)
+            except ValueError:
+                continue
+
+    # Group segments by label
+    groups = {}
+    for (seg_id, path, feat), label in zip(segment_ids, labels):
+        groups.setdefault(label, []).append((seg_id, path, feat))
+
+    for label, items in groups.items():
+        centroid = centroids[label]
+        # pick up to 10 closest segments
+        items.sort(key=lambda x: abs(x[2] - centroid))
+        selected = items[:10]
+
+        best_name = None
+        best_diff = math.inf
+        for name, info in global_map.items():
+            samples = info.get("samples", [])
+            if not samples:
+                continue
+            avg = sum(samples) / len(samples)
+            diff = abs(avg - centroid)
+            if diff < best_diff:
+                best_diff = diff
+                best_name = name
+
+        if best_name is None or best_diff > 500:
+            speaker_name = f"speaker_{next_index}"
+            next_index += 1
+            global_map[speaker_name] = {"samples": [centroid]}
+        else:
+            speaker_name = best_name
+            global_map[speaker_name]["samples"].append(centroid)
+
+        cursor.executemany(
+            "UPDATE segments SET speaker_id=? WHERE id=?",
+            [(speaker_name, seg_id) for seg_id, _, _ in items],
+        )
+
+    conn.commit()
+    conn.close()
+    GLOBAL_SPEAKERS_PATH.write_text(json.dumps(global_map, indent=2))
+
+
+@app.post("/api/recordings/{recording_id}/identify")
+def identify_recording(recording_id: int, background_tasks: BackgroundTasks):
+    background_tasks.add_task(run_speaker_identification, recording_id)
+    return {"status": "started"}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -61,6 +61,7 @@
         <th>Filename</th>
         <th>Duration</th>
         <th>Segments</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody></tbody>
@@ -102,7 +103,10 @@
           <td>
             <a href="#" onclick="showSegments(${rec.id}, '${rec.filename}'); return false;">
               ${rec.segment_count}
-            </a> |
+            </a>
+          </td>
+          <td>
+            <button onclick="identifySpeakers(${rec.id})">🗣 Identify</button>
             <a href="#" onclick="confirmDelete(${rec.id}); return false;" style="color:red;">🗑</a>
           </td>
         `;
@@ -154,6 +158,16 @@
     function playSegment(url) {
       const audio = new Audio(url);
       audio.play();
+    }
+
+    async function identifySpeakers(id) {
+      const res = await fetch(`/api/recordings/${id}/identify`, { method: 'POST' });
+      if (res.ok) {
+        alert('🔍 Speaker identification started');
+      } else {
+        const data = await res.json().catch(() => ({}));
+        alert(`❌ Failed: ${data.detail || res.status}`);
+      }
     }
 
     async function loadJobs() {


### PR DESCRIPTION
## Summary
- add background speaker identification using simple 1D clustering and global speaker store
- expose POST endpoint to trigger background speaker identification per recording
- add dashboard button to start speaker identification for a recording

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6891ef38da888321923bb8e3dc367567