### PR TITLE
fix job watcher SyntaxError

### DIFF
--- a/scripts/job_watcher.py
+++ b/scripts/job_watcher.py
@@ -35,17 +35,6 @@ def scan_for_new_files():
                     continue
 
                 # Skip files already queued as jobs
-    if not AUDIO_DIR or not DB_PATH:
-        raise RuntimeError("AUDIO and TRANSCRIPTS_DB must be set in the environment")
-
-    audio_dir = Path(AUDIO_DIR)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-
-    print(f"📡 Monitoring '{audio_dir}' for new audio files...")
-    try:
-        while True:
-            for path in audio_dir.rglob("*.m4a"):
                 cursor.execute("SELECT 1 FROM jobs WHERE file_path = ?", (str(path),))
                 if cursor.fetchone():
                     continue


### PR DESCRIPTION
## Summary
- remove duplicated environment setup block from job_watcher
- ensure watcher skips already processed recordings and queued jobs before adding new jobs

## Testing
- `python -m py_compile scripts/job_watcher.py`
- `AUDIO=temp_audio TRANSCRIPTS_DB=temp.db timeout 3s python scripts/job_watcher.py`

------
https://chatgpt.com/codex/tasks/task_e_68920fa8198883219ad1e224201b21be