### PR TITLE
Create jobs table automatically in job watcher

### DIFF
--- a/scripts/job_watcher.py
+++ b/scripts/job_watcher.py
@@ -19,6 +19,19 @@ def scan_for_new_files():
     conn = sqlite3.connect(DB_PATH)
     cursor = conn.cursor()
 
+    # Ensure the jobs table exists so lookups/inserts don't fail
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS jobs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_path TEXT UNIQUE NOT NULL,
+            status TEXT DEFAULT 'pending',
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    conn.commit()
+
     def iter_audio_files():
         for dirpath, _, filenames in os.walk(root_dir):
             for name in filenames:


### PR DESCRIPTION
## Summary
- Prevent sqlite errors by auto-creating `jobs` table on job watcher start

## Testing
- `python -m py_compile scripts/job_watcher.py && echo OK`
- `timeout 2s env AUDIO=/tmp TRANSCRIPTS_DB=transcripts.db python scripts/job_watcher.py`
- `sqlite3 transcripts.db "SELECT name FROM sqlite_master WHERE type='table';"`


------
https://chatgpt.com/codex/tasks/task_e_689213695ad08321ace675b51f1ad52f