### PR TITLE
fix: resolve audio segment path from env

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,14 +7,18 @@ import sqlite3
 from pathlib import Path
 import sys
 import subprocess
+import os
+from dotenv import load_dotenv
 
 sys.path.append(str(Path(__file__).parent / "scripts"))
+
+load_dotenv()
 
 app = FastAPI()
 app.add_middleware(CORSMiddleware, allow_origins=["*"])
 
 DB_PATH = Path(__file__).parent / "transcripts.db"
-AUDIO_SEGMENTS_DIR = "/mnt/audio/audio_segments"
+AUDIO_SEGMENTS_DIR = Path(os.getenv("AUDIO_SEGMENTS", "/mnt/audio/audio_segments"))
 DASHBOARD_DIR = Path(__file__).parent / "dashboard"
 
 # Static mounts

--- a/scripts/transcribe_and_split.py
+++ b/scripts/transcribe_and_split.py
@@ -9,7 +9,7 @@ import whisper
 load_dotenv()
 
 AUDIO_DIR = Path(os.getenv("AUDIO"))
-SEGMENT_DIR = Path(os.getenv("AUDIO_SEGMENTS"))
+SEGMENT_DIR = Path(os.getenv("AUDIO_SEGMENTS", "/mnt/audio/audio_segments")).resolve()
 TRANSCRIPTS_DB = Path(os.getenv("TRANSCRIPTS_DB"))
 
 SEGMENT_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- load environment configuration for audio segment directory
- resolve relative segment paths using AUDIO_SEGMENTS env var during speaker identification
- default segment directory to `/mnt/audio/audio_segments` when not specified

## Testing
- `python -m py_compile app.py scripts/transcribe_and_split.py scripts/speaker_identification.py`


------
https://chatgpt.com/codex/tasks/task_e_689215f021b48321b2097cf3a0700797