### PR TITLE
Add routes for dashboard pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,24 @@ def index():
     return FileResponse(DASHBOARD_DIR / "index.html")
 
 
+@app.get("/jobs")
+def jobs_page():
+    """Serve the jobs dashboard page."""
+    return FileResponse(DASHBOARD_DIR / "jobs.html")
+
+
+@app.get("/speakers")
+def speakers_page():
+    """Serve the speakers dashboard page."""
+    return FileResponse(DASHBOARD_DIR / "speakers.html")
+
+
+@app.get("/transcripts")
+def transcripts_page():
+    """Serve the transcripts dashboard page."""
+    return FileResponse(DASHBOARD_DIR / "transcripts.html")
+
+
 @app.get("/api/recordings")
 def get_recordings():
     conn = sqlite3.connect(DB_PATH)


### PR DESCRIPTION
## Summary
- serve jobs, speakers, and transcripts dashboard pages

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689259dc7d4083218f49a4139e8b9cd5