### PR TITLE
Add batch processing options to dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -209,6 +209,17 @@ def identify_recording(recording_id: int, background_tasks: BackgroundTasks):
     return {"status": "started"}
 
 
+class RecordingBatch(BaseModel):
+    recording_ids: list[int]
+
+
+@app.post("/api/recordings/identify_batch")
+def identify_recordings_batch(batch: RecordingBatch, background_tasks: BackgroundTasks):
+    for rid in batch.recording_ids:
+        background_tasks.add_task(run_speaker_identification, rid)
+    return {"status": "started", "count": len(batch.recording_ids)}
+
+
 class SpeakerUpdate(BaseModel):
     label: str
 

--- a/dashboard/jobs.html
+++ b/dashboard/jobs.html
@@ -13,9 +13,11 @@
 <body>
   <h1>🧾 Job Queue</h1>
   <p><a href="/dashboard/index.html">⬅️ Back</a></p>
+  <button id="process-selected">▶️ Process Selected</button>
   <table id="jobs-table">
     <thead>
       <tr>
+        <th><input type="checkbox" id="select-all"></th>
         <th>ID</th>
         <th>File</th>
         <th>Status</th>
@@ -27,6 +29,10 @@
   </table>
 
   <script>
+    function getSelected() {
+      return Array.from(document.querySelectorAll('#jobs-table tbody input[type=checkbox]:checked')).map(cb => parseInt(cb.value));
+    }
+
     async function loadJobs() {
       const res = await fetch('/api/jobs');
       const jobs = await res.json();
@@ -35,6 +41,7 @@
       jobs.forEach(job => {
         const row = document.createElement('tr');
         row.innerHTML = `
+          <td><input type="checkbox" value="${job.id}"></td>
           <td>${job.id}</td>
           <td>${job.file_path}</td>
           <td>${job.status}</td>
@@ -55,6 +62,30 @@
       }
       await loadJobs();
     }
+
+    document.getElementById('process-selected').addEventListener('click', async () => {
+      const ids = getSelected();
+      if (!ids.length) {
+        alert('No jobs selected');
+        return;
+      }
+      const res = await fetch('/api/jobs/batch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ job_ids: ids }),
+      });
+      if (res.ok) {
+        alert('✅ Batch processing started');
+      } else {
+        const data = await res.json().catch(() => ({}));
+        alert(`❌ Failed: ${data.detail || res.status}`);
+      }
+      await loadJobs();
+    });
+
+    document.getElementById('select-all').addEventListener('change', e => {
+      document.querySelectorAll('#jobs-table tbody input[type=checkbox]').forEach(cb => cb.checked = e.target.checked);
+    });
 
     loadJobs();
   </script>

--- a/dashboard/transcripts.html
+++ b/dashboard/transcripts.html
@@ -13,9 +13,11 @@
 <body>
   <h1>📼 Recordings</h1>
   <p><a href="/dashboard/index.html">⬅️ Back</a></p>
+  <button id="identify-selected">🗣 Identify Selected</button>
   <table id="recordings-table">
     <thead>
       <tr>
+        <th><input type="checkbox" id="select-all"></th>
         <th>Datetime</th>
         <th>Filename</th>
         <th>Duration</th>
@@ -26,6 +28,10 @@
     <tbody></tbody>
   </table>
   <script>
+    function getSelected() {
+      return Array.from(document.querySelectorAll('#recordings-table tbody input[type=checkbox]:checked')).map(cb => parseInt(cb.value));
+    }
+
     async function loadRecordings() {
       const res = await fetch('/api/recordings');
       const recs = await res.json();
@@ -34,6 +40,7 @@
       recs.forEach(rec => {
         const row = document.createElement('tr');
         row.innerHTML = `
+          <td><input type="checkbox" value="${rec.id}"></td>
           <td>${rec.datetime}</td>
           <td>${rec.filename}</td>
           <td>${(rec.duration_sec/60).toFixed(1)} min</td>
@@ -58,6 +65,25 @@
       }
     }
 
+    document.getElementById('identify-selected').addEventListener('click', async () => {
+      const ids = getSelected();
+      if (!ids.length) {
+        alert('No recordings selected');
+        return;
+      }
+      const res = await fetch('/api/recordings/identify_batch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recording_ids: ids }),
+      });
+      if (res.ok) {
+        alert('🔍 Batch identification started');
+      } else {
+        const data = await res.json().catch(()=>({}));
+        alert(`❌ Failed: ${data.detail || res.status}`);
+      }
+    });
+
     async function del(id) {
       if (!confirm('Delete recording?')) return;
       const res = await fetch(`/api/recordings/${id}`, {method:'DELETE'});
@@ -67,6 +93,10 @@
         alert('❌ Failed to delete');
       }
     }
+
+    document.getElementById('select-all').addEventListener('change', e => {
+      document.querySelectorAll('#recordings-table tbody input[type=checkbox]').forEach(cb => cb.checked = e.target.checked);
+    });
 
     loadRecordings();
   </script>


### PR DESCRIPTION
## Summary
- add batch API for speaker identification
- allow batch job processing for transcription
- enable selecting multiple recordings for batch identification

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68926dfb407083218c4ba7f58c44eb69