### PR TITLE
Add script to launch monitor and dashboard services together

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ After the server is running, verify the API is responsive:
 # Expect an empty list or existing recordings
 curl http://127.0.0.1:8000/api/recordings
 ```
+
+## Running Monitoring and Dashboard Together
+
+To run the file monitor alongside the dashboard server, use the helper script:
+
+```bash
+python scripts/start_services.py
+```
+
+This launches the monitoring loop and the FastAPI dashboard in one step.

--- a/scripts/start_services.py
+++ b/scripts/start_services.py
@@ -1,0 +1,45 @@
+import subprocess
+import sys
+import logging
+import builtins
+from pathlib import Path
+from logging_config import setup_logging
+
+setup_logging()
+builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
+logger = logging.getLogger(__name__)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main():
+    processes = []
+    try:
+        monitor_cmd = [sys.executable, str(ROOT / "scripts" / "monitor.py")]
+        dashboard_cmd = ["uvicorn", "app:app", "--reload"]
+
+        logger.info("Starting monitor...")
+        processes.append(
+            subprocess.Popen(monitor_cmd, cwd=ROOT / "scripts")
+        )
+
+        logger.info("Starting dashboard server...")
+        processes.append(subprocess.Popen(dashboard_cmd, cwd=ROOT))
+
+        for p in processes:
+            p.wait()
+    except KeyboardInterrupt:
+        logger.info("Shutting down services...")
+    finally:
+        for p in processes:
+            if p.poll() is None:
+                p.terminate()
+        for p in processes:
+            try:
+                p.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                p.kill()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `start_services.py` helper script to boot the monitor and FastAPI dashboard in parallel
- Document the unified start script in the README

## Testing
- `python -m py_compile scripts/start_services.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68945ce1b5a88321a7d6c6bb02831df2