### PR TITLE
Ensure scripts can access logging config

### DIFF
--- a/scripts/Summarise.py
+++ b/scripts/Summarise.py
@@ -4,7 +4,7 @@ import logging
 import builtins
 from dotenv import load_dotenv
 from openai import OpenAI
-from logging_config import setup_logging
+from common import setup_logging
 
 # === Load environment ===
 load_dotenv()

--- a/scripts/Transcribe.py
+++ b/scripts/Transcribe.py
@@ -3,7 +3,7 @@ import logging
 import builtins
 import requests
 from dotenv import load_dotenv
-from logging_config import setup_logging
+from common import setup_logging
 
 # Load environment variables from .env
 load_dotenv()

--- a/scripts/cleanup_jobs.py
+++ b/scripts/cleanup_jobs.py
@@ -3,7 +3,7 @@ import sqlite3
 from pathlib import Path
 import logging
 import builtins
-from logging_config import setup_logging
+from common import setup_logging
 
 try:  # python-dotenv may not be installed
     from dotenv import load_dotenv  # type: ignore

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the Python path
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from logging_config import setup_logging  # noqa: E402

--- a/scripts/email_work_transcript.py
+++ b/scripts/email_work_transcript.py
@@ -4,7 +4,7 @@ import builtins
 import smtplib
 from email.message import EmailMessage
 from dotenv import load_dotenv
-from logging_config import setup_logging
+from common import setup_logging
 
 # === Load environment ===
 load_dotenv()

--- a/scripts/identify_speakers.py
+++ b/scripts/identify_speakers.py
@@ -5,7 +5,7 @@ import logging
 import builtins
 from dotenv import load_dotenv
 from openai import OpenAI
-from logging_config import setup_logging
+from common import setup_logging
 from maintain_global_speakers import (
     load_global_map,
     save_global_map,

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -2,7 +2,7 @@ import sqlite3
 from pathlib import Path
 import logging
 import builtins
-from logging_config import setup_logging
+from common import setup_logging
 
 setup_logging()
 builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)

--- a/scripts/job_watcher.py
+++ b/scripts/job_watcher.py
@@ -4,7 +4,7 @@ import sqlite3
 from pathlib import Path
 import logging
 import builtins
-from logging_config import setup_logging
+from common import setup_logging
 from dotenv import load_dotenv
 
 load_dotenv()

--- a/scripts/maintain_global_speakers.py
+++ b/scripts/maintain_global_speakers.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 import logging
 import builtins
-from logging_config import setup_logging
+from common import setup_logging
 
 GLOBAL_MAP_PATH = "global_speakers.json"
 

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -4,7 +4,7 @@ import subprocess
 import logging
 import builtins
 from dotenv import load_dotenv
-from logging_config import setup_logging
+from common import setup_logging
 
 load_dotenv()
 setup_logging()

--- a/scripts/review_speakers.py
+++ b/scripts/review_speakers.py
@@ -3,7 +3,7 @@ import json
 import logging
 import builtins
 from dotenv import load_dotenv
-from logging_config import setup_logging
+from common import setup_logging
 from maintain_global_speakers import (
     load_global_map,
     save_global_map,

--- a/scripts/speaker_identification.py
+++ b/scripts/speaker_identification.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import os
 import logging
 import builtins
-from logging_config import setup_logging
+from common import setup_logging
 
 import numpy as np
 from resemblyzer import VoiceEncoder, preprocess_wav

--- a/scripts/start_services.py
+++ b/scripts/start_services.py
@@ -3,7 +3,7 @@ import sys
 import logging
 import builtins
 from pathlib import Path
-from logging_config import setup_logging
+from common import setup_logging
 
 setup_logging()
 builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)

--- a/scripts/transcribe_and_split.py
+++ b/scripts/transcribe_and_split.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from pydub import AudioSegment
 from dotenv import load_dotenv
 import whisper
-from logging_config import setup_logging
+from common import setup_logging
 
 # === Load environment ===
 load_dotenv()


### PR DESCRIPTION
## Summary
- add `scripts/common.py` to append repo root to `sys.path` and expose `setup_logging`
- update all scripts to import `setup_logging` from the new helper

## Testing
- `python scripts/init_db.py`

------
https://chatgpt.com/codex/tasks/task_e_6894663f795c8321baae843ba32845b6