### PR TITLE
Fix monitor pipeline exception indentation

### DIFF
--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -48,8 +48,8 @@ def run_pipeline():
         subprocess.run(["python", SUMMARISE_SCRIPT], check=True)
 
         logger.info("✅ All stages completed.\n")
-        except subprocess.CalledProcessError:
-            logger.exception("❌ Error during processing")
+    except subprocess.CalledProcessError:
+        logger.exception("❌ Error during processing")
 
 def monitor_loop():
     logger.info(f"📡 Polling '{AUDIO_DIR}' every {POLL_INTERVAL} seconds...")


### PR DESCRIPTION
## Summary
- Corrected indentation for `except` block in `monitor.py`

## Testing
- `pytest -q`
- `python scripts/start_services.py & sleep 1; kill %1` *(fails: expected str, bytes or os.PathLike object, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_68947a041aa08321b4206840d910b258