### PR TITLE
Fix service startup and logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,9 +6,7 @@ from fastapi.responses import FileResponse
 import sqlite3
 from pathlib import Path
 import sys
-import logging
-import builtins
-from logging_config import setup_logging
+from logging_config import setup_logging, get_logger
 import subprocess
 import os
 from dotenv import load_dotenv
@@ -16,11 +14,11 @@ import numpy as np
 
 sys.path.append(str(Path(__file__).parent / "scripts"))
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
+logger = get_logger(__name__)
 load_dotenv()
 
 # Summarization utilities
-from Summarise import split_text_into_chunks, summarise_chunk, MAX_CHUNKS
+from summarise import split_text_into_chunks, summarise_chunk, MAX_CHUNKS
 
 app = FastAPI()
 app.add_middleware(CORSMiddleware, allow_origins=["*"])

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from pathlib import Path
+import builtins
 
 def setup_logging(level=logging.INFO):
     # Log to stdout and to a file for persistent exception traces
@@ -13,3 +14,25 @@ def setup_logging(level=logging.INFO):
             logging.FileHandler(str(log_file), encoding="utf-8"),
         ],
     )
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a module-specific logger and redirect ``print`` to it.
+
+    The custom ``print`` discards unsupported keyword arguments such as
+    ``file`` that the ``logging`` module does not accept.
+    """
+
+    logger = logging.getLogger(name)
+
+    def log_print(*args, **kwargs):
+        # ``traceback.print_exception`` passes ``file`` and ``end`` arguments;
+        # they are not recognised by ``logger.info`` so remove them.
+        kwargs.pop("file", None)
+        sep = kwargs.pop("sep", " ")
+        end = kwargs.pop("end", "")
+        message = sep.join(str(a) for a in args) + end
+        logger.info(message)
+
+    builtins.print = log_print
+    return logger

--- a/scripts/cleanup_jobs.py
+++ b/scripts/cleanup_jobs.py
@@ -1,9 +1,7 @@
 import os
 import sqlite3
 from pathlib import Path
-import logging
-import builtins
-from common import setup_logging
+from common import setup_logging, get_logger
 
 try:  # python-dotenv may not be installed
     from dotenv import load_dotenv  # type: ignore
@@ -12,8 +10,7 @@ except Exception:  # pragma: no cover
 
 load_dotenv()
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 DB_PATH = os.getenv("TRANSCRIPTS_DB")
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -6,4 +6,4 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
-from logging_config import setup_logging  # noqa: E402
+from logging_config import setup_logging, get_logger  # noqa: E402

--- a/scripts/email_work_transcript.py
+++ b/scripts/email_work_transcript.py
@@ -1,15 +1,13 @@
 import os
-import logging
-import builtins
 import smtplib
 from email.message import EmailMessage
 from dotenv import load_dotenv
-from common import setup_logging
+from common import setup_logging, get_logger
 
 # === Load environment ===
 load_dotenv()
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
+logger = get_logger(__name__)
 SMTP_SERVER = os.getenv("SMTP_SERVER")
 SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
 EMAIL_USER = os.getenv("EMAIL_USER")

--- a/scripts/identify_speakers.py
+++ b/scripts/identify_speakers.py
@@ -1,11 +1,9 @@
 import os
 import re
 import json
-import logging
-import builtins
 from dotenv import load_dotenv
 from openai import OpenAI
-from common import setup_logging
+from common import setup_logging, get_logger
 from maintain_global_speakers import (
     load_global_map,
     save_global_map,
@@ -15,8 +13,7 @@ from maintain_global_speakers import (
 # === Load environment ===
 load_dotenv()
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 TRANSCRIPTS_DIR = os.getenv("TRANSCRIPTS")
 SPEAKER_MAPS_DIR = os.getenv("SPEAKER_MAPS")
@@ -141,8 +138,8 @@ def main():
             save_labelled_transcript(fname, labelled_text)
             print(f"✅ Output saved for {fname}")
 
-            except Exception:
-                logger.exception(f"❌ Failed to process {fname}")
+        except Exception:
+            logger.exception(f"❌ Failed to process {fname}")
 
 if __name__ == "__main__":
     main()

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,11 +1,9 @@
 import sqlite3
 from pathlib import Path
-import logging
-import builtins
-from common import setup_logging
+from common import setup_logging, get_logger
 
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
+logger = get_logger(__name__)
 db_path = Path("transcripts.db")
 db_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/job_watcher.py
+++ b/scripts/job_watcher.py
@@ -2,15 +2,12 @@ import os
 import time
 import sqlite3
 from pathlib import Path
-import logging
-import builtins
-from common import setup_logging
+from common import setup_logging, get_logger
 from dotenv import load_dotenv
 
 load_dotenv()
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 AUDIO_DIR = os.getenv("AUDIO")
 DB_PATH = os.getenv("TRANSCRIPTS_DB")

--- a/scripts/maintain_global_speakers.py
+++ b/scripts/maintain_global_speakers.py
@@ -1,15 +1,12 @@
 import os
 import json
 from datetime import datetime
-import logging
-import builtins
-from common import setup_logging
+from common import setup_logging, get_logger
 
 GLOBAL_MAP_PATH = "global_speakers.json"
 
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 def load_global_map():
     if os.path.exists(GLOBAL_MAP_PATH):

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -1,15 +1,12 @@
 import os
 import time
 import subprocess
-import logging
-import builtins
 from dotenv import load_dotenv
-from common import setup_logging
+from common import setup_logging, get_logger
 
 load_dotenv()
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 AUDIO_DIR = os.getenv("AUDIO")
 TRANSCRIPTS_DIR = os.getenv("TRANSCRIPTS")

--- a/scripts/review_speakers.py
+++ b/scripts/review_speakers.py
@@ -1,9 +1,7 @@
 import os
 import json
-import logging
-import builtins
 from dotenv import load_dotenv
-from common import setup_logging
+from common import setup_logging, get_logger
 from maintain_global_speakers import (
     load_global_map,
     save_global_map,
@@ -13,7 +11,7 @@ from maintain_global_speakers import (
 # === Load environment variables ===
 load_dotenv()
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
+logger = get_logger(__name__)
 SPEAKER_MAPS_DIR = os.getenv("SPEAKER_MAPS")
 TRANSCRIPTS_DIR = os.getenv("TRANSCRIPTS")
 LABELLED_TRANSCRIPTS_DIR = os.getenv("TRANSCRIPTS_LABELLED")

--- a/scripts/speaker_identification.py
+++ b/scripts/speaker_identification.py
@@ -3,9 +3,7 @@ import sys
 from pathlib import Path
 
 import os
-import logging
-import builtins
-from common import setup_logging
+from common import setup_logging, get_logger
 
 import numpy as np
 from resemblyzer import VoiceEncoder, preprocess_wav
@@ -14,8 +12,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 DB_PATH = Path(__file__).resolve().parent.parent / "transcripts.db"
 AUDIO_SEGMENTS_DIR = Path(os.getenv("AUDIO_SEGMENTS", "/mnt/audio/audio_segments"))

--- a/scripts/start_services.py
+++ b/scripts/start_services.py
@@ -1,13 +1,10 @@
 import subprocess
 import sys
-import logging
-import builtins
 from pathlib import Path
-from common import setup_logging
+from common import setup_logging, get_logger
 
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -16,7 +13,7 @@ def main():
     processes = []
     try:
         monitor_cmd = [sys.executable, str(ROOT / "scripts" / "monitor.py")]
-        dashboard_cmd = ["uvicorn", "app:app", "--reload"]
+        dashboard_cmd = ["uvicorn", "app:app", "--reload", "--host", "0.0.0.0"]
 
         logger.info("Starting monitor...")
         processes.append(

--- a/scripts/summarise.py
+++ b/scripts/summarise.py
@@ -1,10 +1,8 @@
 import os
 import json
-import logging
-import builtins
 from dotenv import load_dotenv
 from openai import OpenAI
-from common import setup_logging
+from common import setup_logging, get_logger
 
 # === Load environment ===
 load_dotenv()
@@ -14,8 +12,7 @@ SUMMARY_DIR = os.getenv("SUMMARIES")
 
 client = OpenAI(api_key=OPENAI_API_KEY)
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args))
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # === Parameters ===
 CHUNK_SIZE = 7000  # characters

--- a/scripts/transcribe.py
+++ b/scripts/transcribe.py
@@ -1,15 +1,12 @@
 import os
-import logging
-import builtins
 import requests
 from dotenv import load_dotenv
-from common import setup_logging
+from common import setup_logging, get_logger
 
 # Load environment variables from .env
 load_dotenv()
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 API_KEY = os.getenv("WHISPERAPI")
 AUDIO_DIR = os.getenv("AUDIO")
 TRANSCRIPTS_DIR = os.getenv("TRANSCRIPTS")

--- a/scripts/transcribe_and_split.py
+++ b/scripts/transcribe_and_split.py
@@ -1,18 +1,15 @@
 import os
 import sqlite3
-import logging
-import builtins
 from pathlib import Path
 from pydub import AudioSegment
 from dotenv import load_dotenv
 import whisper
-from common import setup_logging
+from common import setup_logging, get_logger
 
 # === Load environment ===
 load_dotenv()
 setup_logging()
-builtins.print = lambda *args, **kwargs: logging.getLogger(__name__).info(" ".join(str(a) for a in args), **kwargs)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 AUDIO_DIR = Path(os.getenv("AUDIO"))
 SEGMENT_DIR = Path(os.getenv("AUDIO_SEGMENTS", "/mnt/audio/audio_segments")).resolve()


### PR DESCRIPTION
## Summary
- prevent logging crashes by routing `print` through a safe logger helper
- use lowercase script names and update imports
- run dashboard server on `0.0.0.0`

## Testing
- `python -m pytest`
- `python -m py_compile app.py logging_config.py scripts/cleanup_jobs.py scripts/common.py scripts/email_work_transcript.py scripts/identify_speakers.py scripts/init_db.py scripts/job_watcher.py scripts/maintain_global_speakers.py scripts/monitor.py scripts/review_speakers.py scripts/speaker_identification.py scripts/start_services.py scripts/summarise.py scripts/transcribe.py scripts/transcribe_and_split.py`


------
https://chatgpt.com/codex/tasks/task_e_68947e3bcf90832194b82504994bddab