### PR TITLE
Containerize transcription pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Create virtual environment and install Python dependencies
+COPY requirements.txt .
+RUN python -m venv /opt/venv \
+    && /opt/venv/bin/pip install --upgrade pip \
+    && /opt/venv/bin/pip install -r requirements.txt
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Copy application code
+COPY . .
+
+EXPOSE 8000
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ python3 scripts/init_db.py
 
 This will create `transcripts.db` (or the file specified by `TRANSCRIPTS_DB` in your `.env`) with the required tables.
 
+## Docker
+
+To run the full pipeline in containers, build the image and start the stack with Docker Compose. Create host directories for audio input, audio segments, and the database, then run:
+
+```bash
+docker-compose up -d
+```
+
+The service mounts the following paths by default (override in `docker-compose.yml`):
+
+* `./audio` → `/mnt/audio`
+* `./audio_segments` → `/mnt/audio_segments`
+* `./db` → `/mnt/db`
+
+Place recordings into the mounted audio directory and they will be processed automatically. Visit the dashboard at [http://localhost:8000/dashboard](http://localhost:8000/dashboard).
+
+
 ## Running the API
 
 Start the FastAPI server:

--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ from summarise import split_text_into_chunks, summarise_chunk, MAX_CHUNKS
 app = FastAPI()
 app.add_middleware(CORSMiddleware, allow_origins=["*"])
 
-DB_PATH = Path(__file__).parent / "transcripts.db"
+DB_PATH = Path(os.getenv("TRANSCRIPTS_DB", Path(__file__).parent / "transcripts.db"))
 AUDIO_SEGMENTS_DIR = Path(os.getenv("AUDIO_SEGMENTS", "/mnt/audio/audio_segments"))
 DASHBOARD_DIR = Path(__file__).parent / "dashboard"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+services:
+  transcription:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./audio:/mnt/audio
+      - ./audio_segments:/mnt/audio_segments
+      - ./db:/mnt/db
+    env_file:
+      - .env
+    environment:
+      AUDIO: /mnt/audio
+      AUDIO_SEGMENTS: /mnt/audio_segments
+      TRANSCRIPTS_DB: /mnt/db/transcripts.db

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+DB_PATH="${TRANSCRIPTS_DB:-/mnt/db/transcripts.db}"
+if [ ! -f "$DB_PATH" ]; then
+    python scripts/init_db.py
+fi
+
+exec python scripts/start_services.py

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,10 +1,12 @@
+import os
 import sqlite3
 from pathlib import Path
 from common import setup_logging, get_logger
 
 setup_logging()
 logger = get_logger(__name__)
-db_path = Path("transcripts.db")
+db_path = Path(os.getenv("TRANSCRIPTS_DB", "transcripts.db"))
+db_path = db_path if db_path.is_absolute() else Path.cwd() / db_path
 db_path.parent.mkdir(parents=True, exist_ok=True)
 
 conn = sqlite3.connect(db_path)

--- a/scripts/label_speakers.py
+++ b/scripts/label_speakers.py
@@ -15,7 +15,7 @@ load_dotenv()
 setup_logging()
 logger = get_logger(__name__)
 
-DB_PATH = Path(__file__).resolve().parent.parent / "transcripts.db"
+DB_PATH = Path(os.getenv("TRANSCRIPTS_DB", Path(__file__).resolve().parent.parent / "transcripts.db"))
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 client = OpenAI(api_key=OPENAI_API_KEY)
 

--- a/scripts/speaker_identification.py
+++ b/scripts/speaker_identification.py
@@ -14,7 +14,7 @@ load_dotenv()
 setup_logging()
 logger = get_logger(__name__)
 
-DB_PATH = Path(__file__).resolve().parent.parent / "transcripts.db"
+DB_PATH = Path(os.getenv("TRANSCRIPTS_DB", Path(__file__).resolve().parent.parent / "transcripts.db"))
 AUDIO_SEGMENTS_DIR = Path(os.getenv("AUDIO_SEGMENTS", "/mnt/audio/audio_segments"))
 
 

--- a/scripts/start_services.py
+++ b/scripts/start_services.py
@@ -13,7 +13,14 @@ def main():
     processes = []
     try:
         monitor_cmd = [sys.executable, str(ROOT / "scripts" / "monitor.py")]
-        dashboard_cmd = ["uvicorn", "app:app", "--reload", "--host", "0.0.0.0"]
+        dashboard_cmd = [
+            "uvicorn",
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8000",
+        ]
 
         logger.info("Starting monitor...")
         processes.append(


### PR DESCRIPTION
## Summary
- Add Dockerfile and entrypoint for running FastAPI app and monitor
- Provide docker-compose setup with volume mounts and env vars
- Make database path configurable via `TRANSCRIPTS_DB`

## Testing
- `python -m py_compile app.py scripts/start_services.py scripts/init_db.py scripts/speaker_identification.py scripts/label_speakers.py`
- `docker --version`
- `docker build .` *(fails: Cannot connect to the Docker daemon)*
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_6895daaea89c8321a35a9573619c6737