### PR TITLE
Ensure entrypoint installs core dependencies

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,12 @@ if [ -f ".venv/bin/activate" ]; then
     source .venv/bin/activate
 fi
 
+# Install dependencies if core packages are missing
+if ! python -c "import fastapi, requests, pydub" >/dev/null 2>&1; then
+    echo "📦 Installing core Python dependencies..."
+    pip install fastapi requests pydub >/dev/null
+fi
+
 # Enforce Python 3.11 for local runs to avoid compatibility issues
 PY_VER=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 if [ "$PY_VER" != "3.11" ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ openai
 resemblyzer
 openai-whisper
 webrtcvad
+pydub


### PR DESCRIPTION
## Summary
- Auto-install FastAPI, Requests, and Pydub when starting services
- Declare Pydub in requirements

## Testing
- `timeout 20 ./entrypoint.sh` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6895f415800c83219518f41a64b5105f