### PR TITLE
fix: install all dependencies

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,9 @@ if [ -f ".venv/bin/activate" ]; then
 fi
 
 # Install dependencies if core packages are missing
-if ! python -c "import fastapi, requests, pydub" >/dev/null 2>&1; then
+if ! python -c "import fastapi, requests, pydub, dotenv" >/dev/null 2>&1; then
     echo "📦 Installing core Python dependencies..."
-    pip install fastapi requests pydub >/dev/null
+    pip install -r requirements.txt >/dev/null
 fi
 
 # Enforce Python 3.11 for local runs to avoid compatibility issues


### PR DESCRIPTION
## Summary
- install project requirements when core deps are missing

## Testing
- `pip uninstall -y fastapi python-dotenv`
- `timeout 5 ./entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895f6deeea88321ae55d9cd5e880e37